### PR TITLE
Bugfix when disposing the resource handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vs
+bin
+obj

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # dotnet-ResourceAccessManager
+
 Manages exclusive access to named resources in a TPL friendly manner.
+
+## Notes
+
+1. `AquireExclusiveAccessAsync` should always be called with a timeout, or an `CancellationToken`
+having a timeout set.
+
+2. Nested calls to `AquireExclusiveAccessAsync` for the same resource are not supported by design.
+
+## Usage example
+
+```c#
+static async Task Example1(string fileName)
+{
+    using (await ResourceAccessManager.Default.AquireExclusiveAccessAsync(fileName, TimeSpan.FromSeconds(5)))
+    {
+        // do something with the file, 
+        // you've got exclusive access to it (within your application)
+    }
+}
+```


### PR DESCRIPTION
Fixed a bug when disposing a resource handle twice, which by itself could be considered a bug in the caller.
Improved documentation.